### PR TITLE
chore: minor touchup for the README file and link its instructions in the examples directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,22 +19,20 @@ The provider is available at [pulumi registry](https://www.pulumi.com/registry/p
 make install_latest
 ```
 
-- You can try to run examples:
+### Running the examples
+
+To run examples, make sure you have a mnemonic and a network set.
 
 ```bash
-cd examples/go/virtual_machine
 
 export MNEMONIC="mnemonic words"
 export NETWORK="network" # dev, qa, test, main -> default is dev
 
-make run
 ```
+- Go to the examples directory `cd examples/go/virtual_machine`
+- Run the example `make run` 
+- To cleanup the resources that you created `make destroy`
 
-- to destroy the resources you created:
-
-```bash
-make destroy
-```
 
 ## Building The Provider (for development only)
 
@@ -49,7 +47,7 @@ export MNEMONIC="mnemonic words"
 export NETWORK="network" # dev, qa, test, main -> default is dev
 ```
 
-- ### Integration tests
+### Integration tests
 
 ```bash
 make integration

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,13 @@
+# Running the examples
+
+To run examples, make sure you have a mnemonic and a network set.
+
+```bash
+
+export MNEMONIC="mnemonic words"
+export NETWORK="network" # dev, qa, test, main -> default is dev
+```
+
+- Go to the examples directory `cd yaml/virtual_machine`
+- Run the example `make run`
+- To cleanup the resources that you created `make destroy`


### PR DESCRIPTION
chore: minor touchup for the README file and link its instructions in the examples directory

